### PR TITLE
优化生成下载URL的路径兼容性

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,11 +2,14 @@
 import os
 
 
+# 项目根目录
+PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
+
 # 保存剪映草稿的目录
-DRAFT_DIR = os.path.join(os.path.dirname(__file__), "output", "draft")
+DRAFT_DIR = os.path.join(PROJECT_ROOT, "output", "draft")
 
 # 临时文件目录
-TEMP_DIR = os.path.join(os.path.dirname(__file__), "temp")
+TEMP_DIR = os.path.join(PROJECT_ROOT, "temp")
 
 # 剪映草稿的下载路径
 DRAFT_URL = os.getenv("DRAFT_URL", "https://capcut-mate.jcaigc.cn/openapi/capcut-mate/v1/get_draft")

--- a/src/service/get_draft.py
+++ b/src/service/get_draft.py
@@ -15,8 +15,18 @@ def gen_download_url(file_path: str) -> str:
     Returns:
         download_url: 下载URL
     """
-    # 替换文件路径中的/app/为DOWNLOAD_URL
-    download_url = file_path.replace("/app/", config.DOWNLOAD_URL)
+    try:
+        relative_path = os.path.relpath(file_path, config.PROJECT_ROOT)
+    except ValueError:
+        # 如果路径不在同一驱动器等情况
+        relative_path = file_path
+
+    # 将系统路径分隔符转换为URL的正斜杠
+    relative_path = relative_path.replace(os.sep, "/")
+    
+    # 拼接URL
+    base_url = config.DOWNLOAD_URL.rstrip("/")
+    download_url = f"{base_url}/{relative_path}"
     return download_url
 
 def batch_gen_download_url(file_paths: List[str]) -> List[str]:


### PR DESCRIPTION
原始路径写死/app/，在非docker部署容易遇到路径不匹配，无法替换成域名，导致文件下载失败